### PR TITLE
Fix language handling  #19

### DIFF
--- a/title.module
+++ b/title.module
@@ -557,11 +557,12 @@ function title_active_language($langcode = NULL) {
  *   A language code
  */
 function title_entity_language($entity_type, $entity) {
+  $langcode = NULL;
   if (module_exists('translation') && entity_translation_enabled($entity_type)) {
     $handler = entity_translation_get_handler($entity_type, $entity, TRUE);
     $langcode = $handler->getLanguage();
   }
-  else {
+  else if (isset($entity->langcode)) {
     $langcode = $entity->langcode;
   }
   return !empty($langcode) ? $langcode : LANGUAGE_NONE;
@@ -615,7 +616,7 @@ function title_field_attach_submit($entity_type, $entity, $form, &$form_state) {
     // backdrop_array_set_nested_value().
     $values = $form_state['values'];
     $values = backdrop_array_get_nested_value($values, $form['#parents']);
-    $langcode = entity_language($entity_type, $entity);
+    $langcode = title_entity_language($entity_type, $entity);
 
     foreach ($fr_info as $legacy_field => $info) {
       if (!empty($form[$legacy_field]['#field_replacement'])) {
@@ -756,7 +757,7 @@ function title_tokens_alter(array &$replacements, array $context) {
       // the current working language, that is the entity language. Modules
       // using Title tokens in display contexts need to specify the current
       // display language.
-      $langcode = isset($options['language']) ? $options['language']->language : entity_language($entity_type, $entity);
+      $langcode = isset($options['language']) ? $options['language']->langcode : title_entity_language($entity_type, $entity);
 
       if ($fr_info) {
         foreach ($fr_info as $legacy_field => $info) {


### PR DESCRIPTION
title_entity_language is attempting to access $langcode even if it's undefined. I also found an instance in the tokens where the code was referencing the Drupal 7 $language property rather than the Backdrop $langcode property.

Fixes #19